### PR TITLE
Add grantmakers/grantmakers.github.io & add comments.

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -1,5 +1,13 @@
 #!/bin/bash -xe
 
+# Tiny site to get the ball rolling.
 script/build-repo https://github.com/parkr/stuff
+
+# Ben's site is great at catching weird bugs.
 script/build-repo https://github.com/benbalter/benbalter.github.com
+
+# 18F has been a huge user & supporter of Jekyll.
 script/build-repo https://github.com/18F/federalist-docs
+
+# Add this site because the author said it takes 15 minutes to build.
+script/build-repo https://github.com/grantmakers/grantmakers.github.io

--- a/script/cibuild
+++ b/script/cibuild
@@ -12,5 +12,11 @@ script/build-repo https://github.com/18F/federalist-docs
 # @mmistakes is one of our most prolific theme writers & people love this theme.
 script/build-repo https://github.com/mmistakes/minimal-mistakes
 
+# Something with plenty of non-ASCII characters.
+script/build-repo https://github.com/Gaohaoyang/gaohaoyang.github.io
+
+# They like us, right?
+script/build-repo https://github.com/twbs/bootstrap-blog
+
 # Add this site because the author said it takes 15 minutes to build.
 script/build-repo https://github.com/grantmakers/grantmakers.github.io

--- a/script/cibuild
+++ b/script/cibuild
@@ -9,5 +9,8 @@ script/build-repo https://github.com/benbalter/benbalter.github.com
 # 18F has been a huge user & supporter of Jekyll.
 script/build-repo https://github.com/18F/federalist-docs
 
+# @mmistakes is one of our most prolific theme writers & people love this theme.
+script/build-repo https://github.com/mmistakes/minimal-mistakes
+
 # Add this site because the author said it takes 15 minutes to build.
 script/build-repo https://github.com/grantmakers/grantmakers.github.io


### PR DESCRIPTION
This repo houses some tiny scripts to run Jekyll `master` against some hand-picked websites once a day. The purpose of this is to promote & validate Jekyll's stability beyond unit & integration tests. More in the README.

@benbalter, are there any other sites you think we should test each night?

/cc @jekyll/stability