### PR TITLE
Remove jekyll-remote-theme from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,3 @@ versions.each do |gem_name, version|
 end
 
 gem "redcarpet" # 18F/federalist-docs
-gem "jekyll-remote-theme" # benbalter/benbalter.github.com


### PR DESCRIPTION
It's genpop shipped in github-pages.