### PR TITLE
Fix build by no longer including all plugins in :jekyll_plugins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ end
 
 gem "redcarpet" # 18F/federalist-docs
 gem "uswds-jekyll" # 18F/federalist-docs
+gem "jekyll_pages_api_search", group: :jekyll_plugins # 18F/federalist-docs

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ versions.each do |gem_name, version|
 end
 
 gem "redcarpet" # 18F/federalist-docs
+gem "uswds-jekyll" # 18F/federalist-docs

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
 gem "jekyll", git: "https://github.com/jekyll/jekyll", branch: "master"
 versions.each do |gem_name, version|
-  gem gem_name, version, group: :jekyll_plugins if gem_name.start_with?("jekyll-") || gem_name == "jemoji"
+  gem gem_name, version if gem_name.start_with?("jekyll-") || gem_name == "jemoji"
 end
 
 gem "redcarpet" # 18F/federalist-docs

--- a/script/build-repo
+++ b/script/build-repo
@@ -19,4 +19,4 @@ fi
 echo " ==> Cloning $clone_url into $clone_location"
 git clone --recurse-submodules -q "$clone_url" "$clone_location"
 echo " ==> Building it..."
-BUNDLE_GEMFILE=$(pwd)/Gemfile bundle exec jekyll build -s "$clone_location" -d "$build_location"
+BUNDLE_GEMFILE=$(pwd)/Gemfile bundle exec jekyll build -s "$clone_location" -d "$build_location" --trace


### PR DESCRIPTION
Some new requirements for `18F/federalist-docs` and jekyll-readme-index pulled in a README file from 18F/uswds-jekyll which has `{% render %}` which caused Jekyll to barf.