### PR TITLE
Patch Gemfile to work with jekyll master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,19 @@
 source "https://rubygems.org"
 
+OVERRIDES = %w(jemoji jekyll-commonmark-ghpages)
+
 require 'json'
 require 'open-uri'
 versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
 gem "jekyll", git: "https://github.com/jekyll/jekyll", branch: "master"
 versions.each do |gem_name, version|
-  gem gem_name, version if gem_name.start_with?("jekyll-") || gem_name == "jemoji"
+  gem gem_name, version if gem_name.start_with?("jekyll-") && !OVERRIDES.include?(gem_name)
 end
+
+gem "jekyll-commonmark-ghpages",
+  git: "https://github.com/github/jekyll-commonmark-ghpages",
+  branch: "rouge-2-or-3"
 
 gem "redcarpet" # 18F/federalist-docs
 gem "uswds-jekyll" # 18F/federalist-docs


### PR DESCRIPTION
A bunch of updates have recently been merged to `master` in `jekyll/jekyll` are causing version constraint problems. Trying to fix them here:

1. jekyll-commonmark-ghpages relies on Rouge 2.

⚠️ WIP ⚠️ 