### PR TITLE
Allow versions of i18n lower than 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_script: bundle update
 script: script/cibuild
 sudo: false
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ require 'json'
 require 'open-uri'
 versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
-gem "jekyll", git: "https://github.com/jekyll/jekyll", branch: "master"
+gem "jekyll", git: "https://github.com/jekyll/jekyll", branch: "i18n-allow-lower-versions"
 versions.each do |gem_name, version|
   gem gem_name, version if gem_name.start_with?("jekyll-") && !OVERRIDES.include?(gem_name)
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ require 'json'
 require 'open-uri'
 versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
-gem "jekyll", git: "https://github.com/jekyll/jekyll", branch: "i18n-allow-lower-versions"
+gem "jekyll", git: "https://github.com/jekyll/jekyll", branch: "master"
 versions.each do |gem_name, version|
   gem gem_name, version if gem_name.start_with?("jekyll-") && !OVERRIDES.include?(gem_name)
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-OVERRIDES = %w(jemoji jekyll-commonmark-ghpages)
+OVERRIDES = %w(jekyll-commonmark-ghpages)
 
 require 'json'
 require 'open-uri'
@@ -10,6 +10,8 @@ gem "jekyll", git: "https://github.com/jekyll/jekyll", branch: "i18n-allow-lower
 versions.each do |gem_name, version|
   gem gem_name, version if gem_name.start_with?("jekyll-") && !OVERRIDES.include?(gem_name)
 end
+
+gem "jemoji", versions["jemoji"]
 
 gem "jekyll-commonmark-ghpages",
   git: "https://github.com/github/jekyll-commonmark-ghpages",


### PR DESCRIPTION
The last piece of getting the acceptance test bundle installing is to fix this error:

```text
Resolving dependencies...
Bundler could not find compatible versions for gem "activesupport":
  In Gemfile:
    jekyll-mentions (= 1.3.0) was resolved to 1.3.0, which depends on
      activesupport (~> 4.0)

Could not find gem 'activesupport (~> 4.0)', which is required by gem 'jekyll-mentions (= 1.3.0)', in any of
the sources.

Bundler could not find compatible versions for gem "i18n":
  In Gemfile:
    jekyll-mentions (= 1.3.0) was resolved to 1.3.0, which depends on
      activesupport (~> 4.0) was resolved to 4.0.3, which depends on
        i18n (>= 0.6.4, ~> 0.6)

    jekyll was resolved to 3.8.2, which depends on
      i18n (~> 1.0)
```

My solution requires a change to Jekyll, which I have submitted here: https://github.com/jekyll/jekyll/pull/7044