### PR TITLE
Make changes to get builds running properly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,18 @@ end
 gem "jemoji", versions["jemoji"]
 gem "jekyll-include-cache"
 gem "jekyll-remote-theme", ">= 0.4.2"
+
+=begin  # Plugins needed to build 'DirtyF/frank.taillandier.me'
+group :dirtyf do
+  gem "classifier-reborn"
+  gem "jekyll-cloudinary"
+  gem "jekyll-compose"
+  gem "jekyll-microtypo"
+  gem "jekyll-purgecss"
+  gem "jekyll-pwa-workbox"
+  gem "jekyll-tidy"
+  gem "jekyll-typogrify"
+  gem "jekyll-last-modified-at"
+  gem "jekyll_reading_time", git: "https://github.com/DirtyF/jekyll_reading_time"
+end
+=end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source "https://rubygems.org"
 
-OVERRIDES = %w(jekyll-commonmark-ghpages)
+OVERRIDES = %w(
+  jekyll-sass-converter
+  jekyll-default-layout
+  jekyll-remote-theme
+)
 
 require 'json'
 require 'open-uri'
@@ -8,15 +12,10 @@ versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
 gem "jekyll", git: "https://github.com/jekyll/jekyll", branch: "master"
 versions.each do |gem_name, version|
+  next if gem_name.start_with?("jekyll-theme-")
   gem gem_name, version if gem_name.start_with?("jekyll-") && !OVERRIDES.include?(gem_name)
 end
 
 gem "jemoji", versions["jemoji"]
-
-gem "jekyll-commonmark-ghpages",
-  git: "https://github.com/github/jekyll-commonmark-ghpages",
-  branch: "rouge-2-or-3"
-
-gem "redcarpet" # 18F/federalist-docs
-gem "uswds-jekyll" # 18F/federalist-docs
-gem "jekyll_pages_api_search", group: :jekyll_plugins # 18F/federalist-docs
+gem "jekyll-include-cache"
+gem "jekyll-remote-theme", ">= 0.4.2"

--- a/script/cibuild
+++ b/script/cibuild
@@ -9,7 +9,8 @@ time script/build-repo https://github.com/parkr/stuff
 # time script/build-repo https://github.com/benbalter/benbalter.github.com
 
 # Frank's blog made use of many plugins
-time script/build-repo https://github.com/DirtyF/frank.taillandier.me
+# However, the site activates various plugins via Bundler only
+# time script/build-repo https://github.com/DirtyF/frank.taillandier.me
 
 # @mmistakes is one of our most prolific theme writers & people love this theme.
 time script/build-repo https://github.com/mmistakes/minimal-mistakes

--- a/script/cibuild
+++ b/script/cibuild
@@ -9,9 +9,6 @@ time script/build-repo https://github.com/benbalter/benbalter.github.com
 # Frank's blog made use of many plugins
 time script/build-repo https://github.com/DirtyF/frank.taillandier.me
 
-# 18F has been a huge user & supporter of Jekyll.
-time script/build-repo https://github.com/18F/federalist-docs
-
 # @mmistakes is one of our most prolific theme writers & people love this theme.
 time script/build-repo https://github.com/mmistakes/minimal-mistakes
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -4,7 +4,9 @@
 time script/build-repo https://github.com/parkr/stuff
 
 # Ben's site is great at catching weird bugs.
-time script/build-repo https://github.com/benbalter/benbalter.github.com
+# The `retlab` theme has 'github-pages' listed as a runtime_dependency which
+#   can mess with our bundle environment.
+# time script/build-repo https://github.com/benbalter/benbalter.github.com
 
 # Frank's blog made use of many plugins
 time script/build-repo https://github.com/DirtyF/frank.taillandier.me


### PR DESCRIPTION
- `"jekyll-theme-*"` bundled with `github-pages` don't support Jekyll 4.0 yet.
- `"jekyll-default-layout"` plugin doesn't support Jekyll 4.0 yet.
- `18F/federalist-docs` repo has been archived.
- The Jekyll site maintained by `18F` has plugins that don't support Jekyll 4.0