### PR TITLE
chore(ci): bump Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ before_script: bundle update
 script: script/cibuild
 sudo: false
 rvm:
-- 2.6.3
-- 2.4.6
+- 2.7.1
+- 2.5.8
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
+dist: bionic
+os: linux
 language: ruby
 before_script: bundle update
 script: script/cibuild
-sudo: false
+
 rvm:
 - 2.7.1
 - 2.5.8
+
 notifications:
   email: false
   slack:


### PR DESCRIPTION
Annual bump 🎂 

Ruby 2.4 is now EOL.